### PR TITLE
RealBench edit

### DIFF
--- a/Assets/Scenes/RealWorldBenchmark.unity
+++ b/Assets/Scenes/RealWorldBenchmark.unity
@@ -629,7 +629,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 296839164}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 300.9663, y: -574.26807, z: 2302.6584}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -1689,7 +1689,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1251268678}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -349, y: -362.5, z: 0}
+  m_LocalPosition: {x: -136, y: -240.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 93691696}
@@ -1726,7 +1726,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1266719186}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -447, y: -300.5, z: 0}
+  m_LocalPosition: {x: -234, y: -178.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1433933361}
@@ -2154,7 +2154,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1433933357}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 850, y: 437.5, z: 0}
+  m_LocalPosition: {x: 637, y: 315.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1437274968}
@@ -2194,7 +2194,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1437274967}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -736.81, y: 0, z: 0}
+  m_LocalPosition: {x: -523.81, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 834205116}
@@ -2530,7 +2530,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1957946355}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -717, y: -335, z: 0}
+  m_LocalPosition: {x: -504, y: -213, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1433933361}
@@ -2753,7 +2753,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2014353985}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -76.19, y: -407.5, z: 0}
+  m_LocalPosition: {x: -76.19, y: -285.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 559089309}


### PR DESCRIPTION
Camera is now closer, like in a game session in order to reduce the unrealistic overhead of rendering the entire world at once.

The player also moves freely now instead of going between two points.

Added a second repo: https://github.com/Muff1nz/TGAG_PythonScripts with a script for parsing and graphing the fps over time data that realbench now produces. The script works by taking the full file path as a command line argument.

image of a graph(one line per step):
![image](https://user-images.githubusercontent.com/29259118/36932047-8c0603da-1ec3-11e8-90e9-8e4f921441c6.png)

Soure file for graph:
[TGAG_Real_Benchmark_636556650531838506.txt](https://github.com/Hifoz/TGAG/files/1777252/TGAG_Real_Benchmark_636556650531838506.txt)

