### PR TITLE
Added KeyFrameTriggers to animations

### DIFF
--- a/Assets/Kino/KinoFog License.meta
+++ b/Assets/Kino/KinoFog License.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: ca271c4f1af6d1246ba4909e37b1a255
+timeCreated: 1523868313
+licenseType: Free
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Animals/LandAnimal/LandAnimal.cs
+++ b/Assets/Scripts/Animals/LandAnimal/LandAnimal.cs
@@ -66,7 +66,8 @@ public class LandAnimal : Animal {
 
         walkingAnimation = new AnimalAnimation();
         int walkingAnimationFrameCount = 4;
-
+        //Example trigger setup
+        KeyFrameTrigger[] triggers = new KeyFrameTrigger[]{ () => { Debug.Log("TriggerTest!"); }, null, null, null };
         Vector3[] legJoint1Frames = new Vector3[] { new Vector3(0, -45, 45), new Vector3(0, 0, 45), new Vector3(0, 45, 45), new Vector3(0, 0, 75) };
         Vector3[] legJoint2Frames = new Vector3[] { new Vector3(0, 0, -90), new Vector3(0, 0, -90), new Vector3(0, 0, -90), new Vector3(0, 0, -45) };
         for (int i = 0; i < legPairs; i++) {
@@ -82,6 +83,12 @@ public class LandAnimal : Animal {
             leg1_2.setRotations(legJoint2Frames);
             leg2_1.setRotations(Utils.shiftArray(Utils.multVectorArray(legJoint1Frames, -1), 2));
             leg2_2.setRotations(Utils.shiftArray(Utils.multVectorArray(legJoint2Frames, -1), 2));
+
+            //Set the triggers
+            leg1_1.setTriggers(triggers);
+            leg1_2.setTriggers(triggers);
+            leg2_1.setTriggers(triggers);
+            leg2_2.setTriggers(triggers);
 
             walkingAnimation.add(leg1_1);
             walkingAnimation.add(leg1_2);


### PR DESCRIPTION
There is now a 
```
public delegate void KeyFrameTrigger();
```
You can set an array of KeyFrameTrigger in BoneKeyFrames along with the arrays of rotations, positions and scales. The KeyFrameTrigger will be called when a new keyframe is active, so when the animation has interpolated fully into key frame 2 for instance, triggers[2] will be called. 

When interpolating between BoneKeyFrame animations for animation transition, only the triggers from the currently active animation will be called, so when doing Animation1->Animation2 transition, only Animation1 triggers will be triggered. This is because i dont know what it would mean to interpolate between two instances of a void function. 

There is testing code of triggers in the LandAnimal animation, you can change/remove this.
